### PR TITLE
add g:haskell_indent_disable_case

### DIFF
--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -130,9 +130,13 @@ function! GetHaskellIndent() abort
 
   if line =~# '\<case\>.*\<of\>.*\%(\s*--.*\)\?$' && line !~# '^\s*#'
     if line =~# '\<case\>.*\<of\>\s*[[:alnum:](]'
-      return match(line, '\<case\>.*\<of\>\s*\zs\S')
+      return exists('g:haskell_indent_disable_case') && g:haskell_indent_disable_case
+      \      ? indent(s:prevnonblank(v:lnum - 1)) + &shiftwidth
+      \      : match(line, '\<case\>.*\<of\>\s*\zs\S')
     else
-      return match(line, '.*\<case\>\s*\zs')
+      return exists('g:haskell_indent_disable_case') && g:haskell_indent_disable_case
+      \      ? indent(s:prevnonblank(v:lnum - 1)) + &shiftwidth
+      \      : match(line, '.*\<case\>\s*\zs')
     endif
   endif
 


### PR DESCRIPTION
This is a mere proposal.
I want to disable vim-haskell-indent in 'case' only.
Can you accept this?

And sorry, test was not implmented for this.

- - -

これは単なる一つの提案に過ぎません。
私はcase文のみvim-haskell-indentを無効にしたいです。
どうでしょうか？

そしてすみません、これのためのテストはまだ書かれていません :sob: 