### PR TITLE
Allow spaces between `\` and `case` in lambda case expressions

### DIFF
--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -2,7 +2,7 @@
 " Filename: indent/haskell.vim
 " Author: itchyny
 " License: MIT License
-" Last Change: 2023/11/07 19:40:39.
+" Last Change: 2024/08/04 16:24:02.
 " =============================================================================
 
 if exists('b:did_indent')
@@ -174,7 +174,7 @@ function! GetHaskellIndent() abort
     endif
   endif
 
-  if line =~# '\v\\case\s*%(--.*)?$'
+  if line =~# '\v\\\s*<case>\s*%(--.*)?$'
     return match(line, '\v^\s*%(<where>|.*<let>)?\s*\zs') + &shiftwidth
   endif
 


### PR DESCRIPTION
It is syntactically permitted to insert spaces between `\` and `case` in a lambda case expression e.g. `\  case x -> ...`. Fix pattern to match these.

Might be too insignificant to add tests on this, but the choice is yours.