### PR TITLE
Support multiway-lambda expressions

### DIFF
--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -178,6 +178,14 @@ function! GetHaskellIndent() abort
     return match(line, '\v^\s*%(<where>|.*<let>)?\s*\zs') + &shiftwidth
   endif
 
+  if line =~# '\v\\\s*<cases>\s*%(--.*)?$'
+    return match(line, '\v^\s*%(<where>|.*<let>)?\s*\zs') + &shiftwidth
+  endif
+
+  if line =~# '\v\\\s*<cases>\s*[[:alnum:](-\"'']' 
+    return match(line, '\v\\\s*<cases>\s*\zs\S')
+  endif
+
   if nonblankline =~# '\v^.*[^|]\|[^|].*\='
     return s:after_guard()
   endif

--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -182,7 +182,7 @@ function! GetHaskellIndent() abort
     return match(line, '\v^\s*%(<where>|.*<let>)?\s*\zs') + &shiftwidth
   endif
 
-  if line =~# '\v\\\s*<cases>\s*[[:alnum:](-\"'']' 
+  if line =~# '\v\\\s*<cases>\s*[[:alnum:](_\-\"'']' 
     return match(line, '\v\\\s*<cases>\s*\zs\S')
   endif
 

--- a/indent/haskell.vim
+++ b/indent/haskell.vim
@@ -475,6 +475,8 @@ function! s:indent_bar() abort
     let line = getline(i)
     if line =~# '\v^[^[\]]*%([^[\]]*|\[[^[\]]*\])*\[%([^[\]]*|\[[^[\]]*\])*%(--.*)?$'
       return match(line, '\v^[^[\]]*%([^[\]]*|\[[^[\]]*\])*\zs\[([^[\]]*|\[[^[\]]*\])*%(--.*)?$') + &shiftwidth
+    elseif line =~# '\v\\\s*<cases>.*\|'
+      return match(line, '\v\\\s*<cases>.*\zs\|')
     elseif line =~# '\v^\s*%(<where>)?.*[^|]\|[^|].*\='
       return match(line, '\v^\s*%(<where>)?.*[^|]\zs\|[^|].*\=')
     elseif line =~# '\v<data>.*\='

--- a/test/case/cases.in.hs
+++ b/test/case/cases.in.hs
@@ -1,0 +1,6 @@
+printGender :: Language -> Gender -> Text
+printGender = \cases
+English Male   -> "Male"
+English Female -> "Female"
+Chinese Male   -> "男性"
+Chinese Female -> "女性"

--- a/test/case/cases.out.hs
+++ b/test/case/cases.out.hs
@@ -1,0 +1,6 @@
+printGender :: Language -> Gender -> Text
+printGender = \cases
+  English Male   -> "Male"
+  English Female -> "Female"
+  Chinese Male   -> "男性"
+  Chinese Female -> "女性"

--- a/test/case/cases_same_line.in.hs
+++ b/test/case/cases_same_line.in.hs
@@ -1,0 +1,5 @@
+printGender :: Language -> Gender -> Text
+printGender = \cases English Male   -> "Male"
+English Female -> "Female"
+Chinese Male   -> "男性"
+Chinese Female -> "女性"

--- a/test/case/cases_same_line.out.hs
+++ b/test/case/cases_same_line.out.hs
@@ -1,0 +1,5 @@
+printGender :: Language -> Gender -> Text
+printGender = \cases English Male   -> "Male"
+                     English Female -> "Female"
+                     Chinese Male   -> "男性"
+                     Chinese Female -> "女性"

--- a/test/case/casesguard.in.hs
+++ b/test/case/casesguard.in.hs
@@ -1,0 +1,3 @@
+filter = \cases _ []                 -> []
+p (x:xs) | p x       -> x : filter p xs
+| otherwise ->     filter p xs

--- a/test/case/casesguard.out.hs
+++ b/test/case/casesguard.out.hs
@@ -1,0 +1,3 @@
+filter = \cases _ []                 -> []
+                p (x:xs) | p x       -> x : filter p xs
+                         | otherwise ->     filter p xs


### PR DESCRIPTION
Recognise and trigger indentations for [multiway-lambda expressions](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0302-cases.rst).

Example:

```haskell
filter = \cases _ []                 -> []
>>>>>>>>>>>>>>>>p (x:xs) | p x       -> x : filter p xs
                         | otherwise ->     filter p xs
```